### PR TITLE
Add local deb source

### DIFF
--- a/debian.stretch.multistrap
+++ b/debian.stretch.multistrap
@@ -1,9 +1,17 @@
 [General]
-bootstrap=Stretch
-aptsources=Stretch
+bootstrap=Stretch Local
+aptsources=Stretch Local
 configscript=multistrap.configscript
 
+noauth=true
 cleanup=true
+
+[Local]
+source=http://localhost debian/
+omitdebsrc=true
+
+# mesh router
+packages= yggdrasil-go
 
 [Stretch]
 source=http://httpredir.debian.org/debian


### PR DESCRIPTION
`DO NOT MERGE`
----

This is to show what's necessary for multistrap to install from local Debian repository created by:

```
# apt install apache2
# mkdir -p /var/www/html/debian
# cp /vagrant/output/debian-packages/*.deb /var/www/html/debian/
# cd /var/www/html
# dpkg-scanpackages debian /dev/null | gzip -9c > debian/Packages.gz
```
