### PR TITLE
Fix mesh point interface freq set via conf

### DIFF
--- a/packages.d/systemd.customise.add/usr/local/sbin/mesh.setup
+++ b/packages.d/systemd.customise.add/usr/local/sbin/mesh.setup
@@ -35,7 +35,7 @@ ip link set "$INT" down
 iw dev "$INT" set type mp
 ip link set "$INT" down
 
-iw dev "$INT" set freq "$conf_freq"
+iw dev "$INT" set freq "$(echo "$conf_freq" | cut -d' ' -f1)" "$(echo "$conf_freq" | cut -s -d' ' -f2)"
 ip link set "$INT" up
 
 iw dev "$INT" mesh join "$conf_ssid"


### PR DESCRIPTION
While we could simply remove the quotes to address https://github.com/hamishcoleman/debian-minimal-builder/issues/6, this is a more conscious way to parse the `freq` config. This handles omission of the `HT` second parameter with the `cut -s` flag.